### PR TITLE
Add support for powernv builds to qemu tests

### DIFF
--- a/scripts/boot/qemu-powernv
+++ b/scripts/boot/qemu-powernv
@@ -1,0 +1,122 @@
+#!/usr/bin/python3
+#
+# $ cd ~/src/linux
+# $ make
+# $ ~/src/ci-scripts/scripts/boot/qemu-powernv
+#
+# Or:
+#
+# export VMLINUX_PATH=~/src/linux/vmlinux
+# export KERNEL_RELEASE_PATH=~/src/linux/include/config/kernel.release
+#
+# Optional:
+# export QEMU_SYSTEM_PPC64=~/src/qemu/ppc64-softmmu/qemu-system-ppc64
+#
+# export CPU=(POWER8|POWER9)    # Default POWER8
+# export ACCEL=(tcg|kvm)        # Default tcg
+# export SMP=n                  # Default 2 for tcg or 8 for kvm
+#
+# export ROOT_DISK_PATH=~/some/directory
+# Expects ppc64[le]-rootfs.cpio.gz in ROOT_DISK_PATH
+
+import logging
+import os, sys, atexit
+from subprocess import check_call
+sys.path.append(f'{os.path.dirname(sys.argv[0])}/../../lib')
+
+from qemu import *
+from pexpect_utils import *
+from utils import *
+
+def main():
+    setup_logging()
+
+    expected_release = get_expected_release()
+    if expected_release is None:
+        return False
+
+    vmlinux = get_vmlinux()
+    if vmlinux is None:
+        return False
+
+    cpu = get_env_var('CPU', 'POWER8')
+    accel = get_env_var('ACCEL', 'tcg')
+
+    smp = get_env_var('SMP', None)
+    if smp is None:
+        if accel == 'tcg':
+            smp = 2
+        else:
+            smp = 8
+
+    cmdline = 'noreboot'
+
+    if cpu == 'POWER9':
+        machine = 'powernv9'
+    else:
+        machine = 'powernv8'
+
+    cloud_image = os.environ.get('CLOUD_IMAGE', False)
+    if cloud_image:
+        setup_timeout(600)
+
+        # Create snapshot image
+        rdpath = get_root_disk_path()
+        src = f'{rdpath}/{cloud_image}'
+        pid = os.getpid()
+        dst = f'{rdpath}/qemu-temp-{pid}.img'
+        cmd = f'qemu-img create -f qcow2 -F qcow2 -b {src} {dst}'.split()
+        check_call(cmd)
+
+        atexit.register(lambda: os.unlink(dst))
+
+        if 'ubuntu' in cloud_image:
+            cmdline += ' root=/dev/vda1'
+            prompt = 'root@ubuntu:~#'
+        else:
+            cmdline += ' root=/dev/vda2'
+            prompt = '\[root@fedora ~\]#'
+
+        drive = f'-drive file={dst},format=qcow2,if=virtio ' \
+                f'-drive file={rdpath}/cloud-init-user-data.img,if=virtio,format=raw,readonly=on'
+    else:
+        setup_timeout(120)
+        drive = None
+
+    p = PexpectHelper()
+    cmd = qemu_command(vmlinux=vmlinux, machine=machine, cpu=cpu, mem='4G', 
+                       drive=drive, net='-nic user,model=virtio-net-pci',
+                       accel=accel, smp=smp, cmdline=cmdline)
+    p.spawn(cmd, logfile=open('console.log', 'w'))
+
+    if cloud_image:
+        standard_boot(p, prompt=prompt, login=True, password='linuxppc', timeout=300)
+    else:
+        standard_boot(p)
+
+    p.send("echo -n 'booted-revision: '; uname -r")
+    p.expect(f'booted-revision: {expected_release}')
+    p.expect_prompt()
+
+    p.send('cat /proc/cpuinfo')
+    p.expect("IBM PowerNV \(emulated by qemu\)")
+    p.expect_prompt()
+
+    if os.environ.get('QEMU_NET_TESTS', True) != '0':
+        qemu_net_setup(p)
+        ping_test(p)
+        wget_test(p)
+
+    p.send('halt')
+    p.wait_for_exit()
+
+    if filter_log_warnings(open('console.log'), open('warnings.txt', 'w')):
+        logging.error('Errors/warnings seen in console.log')
+        return False
+
+    logging.info('Test completed OK')
+
+    return True
+
+
+sys.exit(0 if main() else 1)


### PR DESCRIPTION
Hello,

I am not sure if this is worth a pull request or not but I figured it helps me so maybe it can be beneficial upstream.

I wanted to try to build and test a kernel configured for powernv. I had built my kernel with the recommended command `sudo make SRC=../../linux-git/ kernel@ppc64le@ubuntu@21.04 DEFCONFIG=powernv_defconfig JFACTOR=$(nproc)` . But the boot script, `qemu-pseries` kept failing. More specifically, it would hang indefinitely when it tried to boot from memory. I was able to resolve the issue by using `powernv` for the `-machine` qemu parameter (previously set to `pseries,cap-htm=off`). I added the ability for the user to set a custom machine type and made a `qemu-powernv` script that calls `qemu-pseries` with the appropriate environment variables set.

Anyway, I would be interested to know if I am totally wrong with this approach. There are too many qemu options to keep track of and its hard to find the best solution.
Thanks! 

Side question: I should probably open an issue for this but I have a feeling it is a misunderstanding on my end. I was having issues with booting the default `ppc64le_defconfig` build. The script `qemu-pseries` kept failing when it got to the network setup function. It could not find the eth0 network device. I was able to fix this issue by setting the network interface card to `e1000` instead of `virtio-net-pci`. The reason I am more confused is because I thought that virtio was supposed to recognize the host hardware and virtualize based on that. It seems weird that the Intel specific driver would work instead of the intuitive driver. That being said I am using an Intel NIC on my host so maybe that lowers the amount of things to go wrong in virtualization land. Anyway, apologies for the long side question, but I will suck it up if it is not an issue for anyone else. Otherwise, I can add a commit for user specified `-nic` parameters.