### PR TITLE
Various updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,15 @@ Other options
 
 As mentioned above you pass the make -j factor with `JFACTOR=n`.
 
-To run sparse use the `ubuntu@21.10` image and pass `SPARSE=1`.
+To run sparse use the `ubuntu@21.10` image and pass `SPARSE=2`.
 
 ```
-$ make SRC=~/src/linux kernel@ppc64le@ubuntu@21.10 SPARSE=1 JFACTOR=$(nproc)
+$ make SRC=~/src/linux kernel@ppc64le@ubuntu@21.10 SPARSE=2 JFACTOR=$(nproc)
 ```
 
 The log will be in eg. `output/ppc64le@ubuntu@21.10/ppc64le_defconfig/sparse.log`.
+
+To only run sparse on files being recompiled, pass `SPARSE=1`.
 
 To build modules pass `MODULES=1`
 

--- a/build/scripts/container-build.sh
+++ b/build/scripts/container-build.sh
@@ -86,7 +86,7 @@ if [[ "$1" == "kernel" ]]; then
         if [[ -n "$SPARSE" ]]; then
             rm -f /output/sparse.log
             touch /output/sparse.log
-            (set -x; make C=2 CF=">> /output/sparse.log 2>&1" $verbose $quiet "$cc" -j $JFACTOR)
+            (set -x; make C=$SPARSE CF=">> /output/sparse.log 2>&1" $verbose $quiet "$cc" -j $JFACTOR)
 
             rc=$?
 

--- a/build/scripts/lib.sh
+++ b/build/scripts/lib.sh
@@ -72,11 +72,11 @@ function get_output_dir()
     return 0
 }
 
-grep "^NAME=Fedora$" /etc/os-release > /dev/null
-if [[ $? -eq 0 ]]; then
-    DOCKER="podman"
-    PODMAN_OPTS="--security-opt label=disable --userns=keep-id"
-else
-    DOCKER="docker"
-    PODMAN_OPTS=""
+DOCKER="docker"
+PODMAN_OPTS=""
+if command -v podman > /dev/null; then
+    if (command -v docker && docker --version | grep -q podman) > /dev/null || ! command -v docker > /dev/null; then
+        DOCKER="podman"
+        PODMAN_OPTS="--security-opt label=disable --userns=keep-id"
+    fi
 fi


### PR DESCRIPTION
This is a set of changes to `ci-scripts` that I have been using for my work. Most of the changes are fairly simple and are described in the commit log.

The fifth patch changes how `SPARSE=1` is interpreted, so if there are some existing scripts/wrappers using that, they may work differently. I'm hoping it isn't too much of a problem, but I can update that patch if you think otherwise.