### PR TITLE
Fix detection of pulled images

### DIFF
--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -151,7 +151,7 @@ if [[ -z "$version" ]]; then
     version=$(get_default_version $distro)
 fi
 
-image="docker.io/linuxppc/build:$distro-$version"
+image="${DOCKER_REGISTRY}linuxppc/build:$distro-$version"
 
 cmd+="$image "
 cmd+="/bin/container-build.sh $task"

--- a/build/scripts/image.sh
+++ b/build/scripts/image.sh
@@ -15,7 +15,7 @@ if [[ -z "$version" ]]; then
     version=$(get_default_version $distro)
 fi
 
-image="docker.io/linuxppc/build:$distro-$version"
+image="${DOCKER_REGISTRY}linuxppc/build:$distro-$version"
 
 if [[ "$task" == "image" ]]; then
     cmd="$DOCKER images -q --filter=reference=$image"
@@ -68,10 +68,10 @@ if [[ -z "$GID" ]]; then
     GID=$(id -g)
 fi
 
-from="docker.io/$distro:$version"
+from="${DOCKER_REGISTRY}$distro:$version"
 
 if [[ "$distro" == "docs" ]]; then
-    from="docker.io/ubuntu:$version"
+    from="${DOCKER_REGISTRY}ubuntu:$version"
 elif [[ "$distro" == "korg" ]]; then
     cmd+="--build-arg compiler_version=$version "
 
@@ -82,9 +82,9 @@ elif [[ "$distro" == "korg" ]]; then
 
     # Use an older distro for the 5.x toolchains.
     if [[ "$version" == 5.* ]]; then
-	from="docker.io/ubuntu:16.04"
+	from="${DOCKER_REGISTRY}ubuntu:16.04"
     else
-	from="docker.io/ubuntu:20.04"
+	from="${DOCKER_REGISTRY}ubuntu:20.04"
     fi
 fi
 

--- a/build/scripts/lib.sh
+++ b/build/scripts/lib.sh
@@ -98,9 +98,11 @@ function get_default_version()
 
 DOCKER="docker"
 PODMAN_OPTS=""
+DOCKER_REGISTRY=""
 if command -v podman > /dev/null; then
     if (command -v docker && docker --version | grep -q podman) > /dev/null || ! command -v docker > /dev/null; then
         DOCKER="podman"
         PODMAN_OPTS="--security-opt label=disable --userns=keep-id"
+        DOCKER_REGISTRY="docker.io/"
     fi
 fi


### PR DESCRIPTION
I noticed that my change regressed docker usage. Please pull in the below fix.

--
While docker can pull images when prefixed with the registry url, it
doesn't include the registry names in the local image repository. Due to
this, trying to detect if an image is present in the local repository
fails causing us to try and build the image again:
	$ make SRC=~/linux kernel@ppc64le@fedora@34
	+ docker images -q --filter=reference=docker.io/linuxppc/build:fedora-34
	+ docker build --pull -f fedora/Dockerfile ... <snip>

Fix this by only appending the registry url for podman.