### PR TITLE
Add support for building architectures other than powerpc and x86

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -19,7 +19,9 @@ KORG_DISTROS := korg@12.1.0 korg@11.1.0 korg@10.3.0 korg@9.3.0 korg@8.1.0 korg@5
 ALL_DISTROS := ${UBUNTU_DISTROS} ${KORG_DISTROS} ${FEDORA_DISTROS}
 DOCS_DISTRO := docs@${UBUNTU_LATEST}
 X86_DISTRO := ubuntu@${UBUNTU_LATEST}
-ALIAS_DISTROS := ubuntu fedora
+ALIAS_DISTROS := ubuntu ubuntu-allcross fedora
+ALLCROSS_DISTROS := ubuntu-allcross@${UBUNTU_LATEST} ubuntu-allcross
+ALL_ARCHES := alpha arm arm64 i686 m68k mips mips64 riscv s390 sh sparc x86_64
 SUBARCHES := ppc64le ppc64 ppc
 
 VERSION:
@@ -112,6 +114,15 @@ $(foreach distro,${FEDORA_DISTROS}, \
 	$(eval $(call SELFTESTS_TEMPLATE,ppc64le,${distro})) \
 )
 endif
+
+$(foreach distro,${ALLCROSS_DISTROS}, \
+	$(foreach subarch,${ALL_ARCHES}, \
+		$(eval $(call MAIN_TEMPLATE,${subarch},${distro})) \
+	) \
+	$(foreach subarch,${ALL_ARCHES}, \
+		$(eval $(call KERNEL_TEMPLATE,${subarch},${distro})) \
+	) \
+)
 
 clean: ${CLEAN}
 	rm -f VERSION

--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -22,17 +22,49 @@ SRC=$(realpath "$SRC")
 
 alternate_binds=$(get_alternate_binds)
 
-arch=powerpc
-if [[ "$subarch" == "ppc64le" ]]; then
+arch=$subarch
+if [[ "$subarch" == "alpha" ]]; then
+    cross="alpha-linux-gnu-"
+elif [[ "$subarch" == "arm" ]]; then
+    cross="arm-linux-gnueabihf-"
+elif [[ "$subarch" == "arm64" ]]; then
+    cross="aarch64-linux-gnu-"
+elif [[ "$subarch" == "i686" ]]; then
+    cross="i686-linux-gnu-"
+    arch=x86
+elif [[ "$subarch" == "m68k" ]]; then
+    cross="m68k-linux-gnu-"
+elif [[ "$subarch" == "mips64" ]]; then
+    cross="mips64el-linux-gnuabi64-"
+    arch=mips
+elif [[ "$subarch" == "mips" ]]; then
+    cross="mipsel-linux-gnu-"
+elif [[ "$subarch" == "riscv" ]]; then
+    cross="riscv64-linux-gnu-"
+elif [[ "$subarch" == "s390" ]]; then
+    cross="s390x-linux-gnu-"
+elif [[ "$subarch" == "sh" ]]; then
+    cross="sh4-linux-gnu-"
+elif [[ "$subarch" == "sparc" ]]; then
+    cross="sparc64-linux-gnu-"
+elif [[ "$subarch" == "x86_64" ]]; then
+    cross="x86_64-linux-gnu-"
+    arch=x86
+elif [[ "$subarch" == "ppc64le" ]]; then
     # No cross compiler for fedora ppc64le on ppc64le
     if [[ "$distro" != "fedora" || $(uname -m) != "ppc64le" ]]; then
 	cross="powerpc64le-linux-gnu-"
     fi
-elif [[ "$subarch" == "x86_64" ]]; then
-    cross="x86_64-linux-gnu-"
-    arch=x86
-else
+    arch=powerpc
+elif [[ "$subarch" == "ppc64" ]]; then
     cross="powerpc64-linux-gnu-"
+    arch=powerpc
+elif [[ "$subarch" == "ppc" ]]; then
+    cross="powerpc-linux-gnu-"
+    arch=powerpc
+else
+    echo "Error: unknown subarch: $subarch" >&2
+    exit 1
 fi
 
 cmd="$DOCKER run --rm "

--- a/build/scripts/image.sh
+++ b/build/scripts/image.sh
@@ -72,6 +72,8 @@ from="${DOCKER_REGISTRY}$distro:$version"
 
 if [[ "$distro" == "docs" ]]; then
     from="${DOCKER_REGISTRY}ubuntu:$version"
+elif [[ "$distro" == "ubuntu-allcross" ]]; then
+	from="${DOCKER_REGISTRY}linuxppc/build:ubuntu-$version-$(uname -m)"
 elif [[ "$distro" == "korg" ]]; then
     cmd+="--build-arg compiler_version=$version "
 

--- a/build/scripts/lib.sh
+++ b/build/scripts/lib.sh
@@ -83,6 +83,7 @@ function get_default_version()
 
     case "$distro" in
         ubuntu) latest="$UBUNTU_LATEST" ;;
+        ubuntu-allcross) latest="$UBUNTU_LATEST" ;;
         fedora) latest="$FEDORA_LATEST" ;;
     esac
 

--- a/build/ubuntu-allcross/Dockerfile
+++ b/build/ubuntu-allcross/Dockerfile
@@ -1,0 +1,27 @@
+ARG from
+FROM ${from}
+
+USER root
+
+ARG apt_mirror
+ENV apt_mirror=${apt_mirror}
+RUN [ -n "$apt_mirror" ] && sed -i -e "s|ports.ubuntu.com|$apt_mirror|" /etc/apt/sources.list || true
+
+RUN apt-get -q -y update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get -q -y install --no-install-recommends \
+      gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+      gcc-alpha-linux-gnu g++-alpha-linux-gnu \
+      gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
+      gcc-i686-linux-gnu g++-i686-linux-gnu \
+      gcc-m68k-linux-gnu g++-m68k-linux-gnu \
+      gcc-mips64el-linux-gnuabi64 g++-mips64el-linux-gnuabi64 \
+      gcc-mipsel-linux-gnu g++-mipsel-linux-gnu \
+      gcc-riscv64-linux-gnu g++-riscv64-linux-gnu \
+      gcc-s390x-linux-gnu g++-s390x-linux-gnu \
+      gcc-sh4-linux-gnu g++-sh4-linux-gnu \
+      gcc-sparc64-linux-gnu g++-sparc64-linux-gnu \
+      && \
+    rm -rf /var/lib/apt/lists/* /var/cache/* /var/log/dpkg.log
+
+USER linuxppc


### PR DESCRIPTION
Add a new image 'ubuntu-allcross' that builds atop linuxppc/build:ubuntu
and includes cross compilers for a few other architectures. Keeping this
image separate allows the more commonly used default image to be small,
aiding quick builds for powerpc.

Add support for using this new image to build for those architectures.