### PR TITLE
Korg 13.1.0 image and few other changes

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -17,7 +17,7 @@ UBUNTU_DISTROS := ubuntu@${UBUNTU_LATEST} ubuntu@20.04 ubuntu@18.04 ubuntu@16.04
 KORG_DISTROS := korg@12.2.0 korg@12.1.0 korg@11.3.0 korg@11.1.0 korg@10.3.0 korg@9.4.0 korg@9.3.0 korg@8.5.0 korg@8.1.0 korg@5.5.0
 ALL_DISTROS := ${UBUNTU_DISTROS} ${KORG_DISTROS} ${FEDORA_DISTROS}
 DOCS_DISTRO := docs@${UBUNTU_LATEST}
-X86_DISTRO := ubuntu@${UBUNTU_LATEST}
+X86_DISTROS := ubuntu@${UBUNTU_LATEST} ubuntu
 ALIAS_DISTROS := ubuntu ubuntu-allcross fedora
 ALLCROSS_DISTROS := ubuntu-allcross@${UBUNTU_LATEST} ubuntu-allcross
 ALL_ARCHES := alpha arm arm64 i686 m68k mips mips64 riscv s390 sh sparc x86_64
@@ -83,11 +83,15 @@ endef
 $(eval $(call MAIN_TEMPLATE,ppc64le,${DOCS_DISTRO}))
 $(eval $(call DOCS_TEMPLATE,ppc64le,${DOCS_DISTRO}))
 
-$(eval $(call MAIN_TEMPLATE,x86_64,${X86_DISTRO}))
-$(eval $(call KERNEL_TEMPLATE,x86_64,${X86_DISTRO}))
+$(foreach distro,${X86_DISTROS}, \
+	$(eval $(call MAIN_TEMPLATE,x86_64,${distro})) \
+	$(eval $(call KERNEL_TEMPLATE,x86_64,${distro})) \
+)
 
 ifeq ($(shell uname -m),x86_64)
-$(eval $(call SELFTESTS_TEMPLATE,x86_64,${X86_DISTRO}))
+$(foreach distro,${X86_DISTROS}, \
+	$(eval $(call SELFTESTS_TEMPLATE,x86_64,${distro})) \
+)
 endif
 
 $(foreach distro,${ALL_DISTROS}, \

--- a/build/Makefile
+++ b/build/Makefile
@@ -14,7 +14,7 @@ endif
 
 FEDORA_DISTROS := fedora@${FEDORA_LATEST} fedora@36 fedora@35 fedora@34 fedora@33 fedora@31 fedora
 UBUNTU_DISTROS := ubuntu@${UBUNTU_LATEST} ubuntu@20.04 ubuntu@18.04 ubuntu@16.04 ubuntu
-KORG_DISTROS := korg@12.2.0 korg@12.1.0 korg@11.3.0 korg@11.1.0 korg@10.3.0 korg@9.4.0 korg@9.3.0 korg@8.5.0 korg@8.1.0 korg@5.5.0
+KORG_DISTROS := korg@13.1.0 korg@12.2.0 korg@12.1.0 korg@11.3.0 korg@11.1.0 korg@10.3.0 korg@9.4.0 korg@9.3.0 korg@8.5.0 korg@8.1.0 korg@5.5.0
 ALL_DISTROS := ${UBUNTU_DISTROS} ${KORG_DISTROS} ${FEDORA_DISTROS}
 DOCS_DISTRO := docs@${UBUNTU_LATEST}
 X86_DISTROS := ubuntu@${UBUNTU_LATEST} ubuntu

--- a/build/korg/Dockerfile
+++ b/build/korg/Dockerfile
@@ -54,6 +54,7 @@ RUN /tmp/make-links.sh ${compiler_version} && rm /tmp/make-links.sh
 ARG uid
 ARG gid
 
+RUN userdel -r ubuntu || true
 RUN groupadd --gid $gid linuxppc
 RUN useradd --uid $uid --gid $gid linuxppc
 USER linuxppc

--- a/build/korg/Dockerfile
+++ b/build/korg/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get -q -y update && \
       libssl-dev \
       lzop \
       make \
+      python3 \
       openssl \
       u-boot-tools \
       rename \

--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -164,7 +164,8 @@ if [[ -n $TARGETS ]]; then
     cmd+="-e TARGETS=$TARGETS "
 fi
 
-output_dir=$(get_output_dir "$script_base" "$subarch" "$distro" "$version" "$task" "$DEFCONFIG" "$TARGETS" "$CLANG")
+output_dir=$(get_output_dir "$script_base" "$subarch" "$distro" "$version" "$task" "$DEFCONFIG" "$TARGETS" "$CLANG" "")
+output_symlink=$(get_output_dir "$script_base" "$subarch" "$distro" "$version" "$task" "$DEFCONFIG" "$TARGETS" "$CLANG" "symlink")
 mkdir -p "$output_dir" || exit 1
 
 cmd+="-v $output_dir:/output:rw "
@@ -202,4 +203,10 @@ cmd+="/bin/container-build.sh $task"
 
 (set -x; $cmd)
 
-exit $?
+ret=$?
+if [[ $ret -eq 0  && -n "$output_symlink" ]]; then
+    rm -f $output_symlink
+    ln -s $output_dir $output_symlink
+fi
+
+exit $ret

--- a/build/scripts/clean.sh
+++ b/build/scripts/clean.sh
@@ -11,6 +11,6 @@ script_base="$(realpath "$dir")"
 
 IFS=@ read -r task subarch distro version <<< "$1"
 
-output_dir=$(get_output_dir "$script_base" "$subarch" "$distro" "$version" "$task" "$DEFCONFIG" "$TARGETS" "$CLANG")
+output_dir=$(get_output_dir "$script_base" "$subarch" "$distro" "$version" "$task" "$DEFCONFIG" "$TARGETS" "$CLANG" "")
 
 (set -x ; rm -rf "$output_dir")

--- a/build/scripts/container-build.sh
+++ b/build/scripts/container-build.sh
@@ -128,6 +128,8 @@ if [[ "$1" == "kernel" ]]; then
 
     echo "## Kernel build completed rc = $rc"
 
+    /linux/scripts/clang-tools/gen_compile_commands.py -o /output/compile_commands.json /output > /dev/null 2>&1 || true
+
     if [[ -f /output/vmlinux ]]; then
         size /output/vmlinux
     fi

--- a/build/scripts/image.sh
+++ b/build/scripts/image.sh
@@ -123,6 +123,8 @@ elif [[ "$distro" == "korg" ]]; then
     # Use an older distro for the 5.x toolchains.
     if [[ "$version" == 5.* ]]; then
 	from="docker.io/ubuntu:16.04"
+    elif [[ "$version" == 13.* ]]; then
+	from="docker.io/ubuntu:23.04"
     else
 	from="docker.io/ubuntu:20.04"
     fi

--- a/build/scripts/lib.sh
+++ b/build/scripts/lib.sh
@@ -25,6 +25,7 @@ function get_output_dir()
     local defconfig="$6"
     local targets="$7"
     local clang="$8"
+    local symlink="$9"
     local d
 
     if [[ -z "$script_base" || -z "$subarch" || -z "$distro" ]]; then
@@ -41,6 +42,10 @@ function get_output_dir()
     case "$task" in
         kernel) ;&
         clean-kernel)
+	    if [[ -n "$symlink" ]]; then
+		echo "$d/latest-kernel"
+		return 0
+	    fi
             if [[ -n "$defconfig" ]]; then
                 defconfig="${defconfig//\//_}"
                 d="$d/$defconfig"
@@ -49,6 +54,10 @@ function get_output_dir()
         ppctests) ;&
         selftests) ;&
         clean-selftests)
+	    if [[ -n "$symlink" ]]; then
+		echo "$d/latest-selftests"
+		return 0
+	    fi
             if [[ -n "$targets" ]]; then
                 targets=${targets// /_}
                 targets=${targets//\//_}
@@ -59,6 +68,10 @@ function get_output_dir()
             ;;
         perf) ;&
         clean-perf)
+	    if [[ -n "$symlink" ]]; then
+		echo "$d/latest-perf"
+		return 0
+	    fi
             d="$d/perf"
             ;;
     esac


### PR DESCRIPTION
I have been running ci-scripts with these changes for a while now, and they are working well for me:
- The first patch is fairly trivial and simplifies x86_64 builds
- The next two patches add support for korg 13.1.0 toolchain
- The last two commits are changes that help in my workflow, but may not be generally applicable. One generates compile_commands.py for use with lang server, while the other adds a symlink 'latest-kernel' in `$CI_OUTPUT` to make it easy to refer to artifacts from the last successful build. These can be left out if they appear too specific.