### PR TITLE
rust: Fix image build error for ubuntu 24.04 or lower

### DIFF
--- a/build/ubuntu/Dockerfile
+++ b/build/ubuntu/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get -q -y update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get -q -y install --no-install-recommends \
       bc \
-      bindgen \
       bison \
       bsdmainutils \
       bzip2 \
@@ -39,8 +38,6 @@ RUN apt-get -q -y update && \
       libfuse-dev \
       liblz4-tool \
       libssl-dev \
-      lld \
-      llvm \
       lzop \
       make \
       openssl \
@@ -49,23 +46,16 @@ RUN apt-get -q -y update && \
       u-boot-tools \
       rename \
       rsync \
-      rustc \
-      rustfmt \
-      rust-clippy \
-      rust-src \
       sparse \
       xz-utils \
       $(/tmp/packages.sh) && \
     rm -rf /var/lib/apt/lists/* /tmp/packages.sh /var/cache/* /var/log/dpkg.log
+
 ENV RUSTUP_HOME=/opt/rustup
 ENV CARGO_HOME=/opt/cargo
 ENV PATH="/opt/cargo/bin:${PATH}"
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-    sh -s -- -y --no-modify-path
-RUN rustup toolchain install nightly-2026-01-28 \
-    && rustup default nightly-2026-01-28 \
-    && rustup component add rust-src --toolchain nightly-2026-01-28 \
-    && cargo install --locked bindgen-cli
+COPY ubuntu/rust-install.sh /tmp/rust-install.sh
+RUN /tmp/rust-install.sh && rm /tmp/rust-install.sh
 COPY ubuntu/make-links.sh /tmp/make-links.sh
 RUN /tmp/make-links.sh ${compiler_version} && rm /tmp/make-links.sh
 

--- a/build/ubuntu/packages.sh
+++ b/build/ubuntu/packages.sh
@@ -9,7 +9,7 @@ machine=$(uname -m)
 major="${VERSION_ID%%.*}"
 
 if [[ "$major" -ge 21 ]]; then
-    PACKAGES+=" clang llvm"
+    PACKAGES+=" clang llvm lld"
 fi
 
 if [[ "$machine" == "ppc64le" ]]; then

--- a/build/ubuntu/rust-install.sh
+++ b/build/ubuntu/rust-install.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+# Source OS release information
+. /etc/os-release
+
+# Extract major version
+major="${VERSION_ID%%.*}"
+
+# Only install Rust for Ubuntu 24.04 and later
+if [[ "$major" -ge 24 ]]; then
+    echo "Installing Rust toolchain for Ubuntu $VERSION_ID..."
+
+    # Set up Rust environment variables
+    export RUSTUP_HOME=/opt/rustup
+    export CARGO_HOME=/opt/cargo
+    export PATH="/opt/cargo/bin:${PATH}"
+
+    # Install rustup
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --no-modify-path
+
+    # Source cargo environment
+    . "$CARGO_HOME/env"
+
+    # Install nightly toolchain with rust-src component
+    rustup toolchain install nightly \
+        && rustup default nightly \
+        && rustup component add rust-src --toolchain nightly \
+        && cargo install --locked bindgen-cli
+
+    # Verify installation
+    echo "Rust toolchain installed successfully:"
+    rustc --version
+    cargo --version
+    bindgen --version
+
+    # Verify rust-src is available
+    if [ -f "$(rustc --print sysroot)/lib/rustlib/src/rust/library/core/src/lib.rs" ]; then
+        echo "rust-src component verified successfully"
+    else
+        echo "WARNING: rust-src component not found at expected location"
+        exit 1
+    fi
+else
+    echo "Skipping Rust installation for Ubuntu $VERSION_ID (requires 24.04 or later)"
+fi
+
+# Made with Bob


### PR DESCRIPTION
ubuntu 16.06 doesn't ships with rust toolchain. Hence the build for the image was failing.

Make sure that the rust toolchain is available only for ubuntu 24.04 or later. For now rust is using nightly toolchain as some required feature for rust-for-linux on ppc64le are not in stable yet. We will switch to stable once it's available.

Tested this with 
ubuntu 24.04
ubuntu 22.04
ubuntu 20.04
ubuntu 18.04
ubuntu 16.04
fedora 42
